### PR TITLE
Add a vcl-reload script that runs permanently to watch for changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -x \
  && apt-get -y install \
     gnupg \
     dirmngr \
+    inotify-tools \
  && for server in $(shuf -e ha.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
                             keyserver.ubuntu.com \
@@ -32,4 +33,5 @@ RUN set -x \
  && rm -rf /var/lib/apt/lists/*
 
 ADD vcl-reload.sh /usr/local/sbin/
+ADD vcl-reload-persistent.sh /usr/local/sbin/
 ADD varnish-logger.sh /usr/local/sbin/

--- a/vcl-reload-persistent.sh
+++ b/vcl-reload-persistent.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+CONFDIR="/etc/varnish"
+
+: ${VCLFILE?"Variable must be define for script to work."}
+: ${INSTANCE?"Variable must be define for script to work."}
+
+if [ ! -d "$CONFDIR" ]; then
+  echo "$CONFDIR must be a directory for script to work"
+  exit 1
+fi
+
+cd "${CONFDIR}"
+
+while inotifywait -qq -r -e modify,close_write,moved_from,delete,delete_self . ; do
+  # make sure vcl is not compiled within the same second (wait for all inotify events to pass)
+  sleep 1
+  NAME="vcl-$(date +%F_%H%M%S)"
+
+  # check if varnish is running correctly
+  varnishadm -n "$INSTANCE" ping || {
+    echo "Not reloading $CONFDIR/$VCLFILE since varnish is not running" > /dev/stderr
+    continue
+  }
+  
+  # cleanup old VCL
+  for vcl in $(varnishadm -n "$INSTANCE" vcl.list | awk '!/^active/ { print $4 }'); do
+      echo "cleaning vcl file '${vcl}'"
+      varnishadm -n "$INSTANCE" vcl.discard "${vcl}"
+  done
+  
+  varnishadm -n "$INSTANCE" vcl.load "${NAME}" "${CONFDIR}/${VCLFILE}"
+  varnishadm -n "$INSTANCE" vcl.use "${NAME}"
+done


### PR DESCRIPTION
This script uses inotifywait will block until a change is made, then the loop body will be executed.
Downside is that if a change is made during the body execution it will not be detected.

Another way to code this is doing a *inotifywait -m | while read [...]*
but then you need a way to avoid running multiple compile because all files were changed at once.
So the simplest and more robust way was choosen.